### PR TITLE
Update dictionary name in example

### DIFF
--- a/Example/main.m
+++ b/Example/main.m
@@ -26,7 +26,7 @@
 
 int main(int argc, const char * argv[]) {
     @autoreleasepool {
-        TTTDictionary *dictionary = [TTTDictionary dictionaryNamed:DCSOxfordEnglishDictionary];
+        TTTDictionary *dictionary = [TTTDictionary dictionaryNamed:DCSOxfordDictionaryOfEnglish];
         NSLog(@"%@\n", dictionary.name);
 
         NSString *term = @"apple";


### PR DESCRIPTION
The example doesn't compile after symbol change in 103cd91506b55444681106a320fa2400545afc73. Updated the dictionary name and now it compiles.
