### PR TITLE
fixed DCSRecordCopyData signature to retrieve HTML & CSS

### DIFF
--- a/DictionaryKit/TTTDictionary.m
+++ b/DictionaryKit/TTTDictionary.m
@@ -52,7 +52,7 @@ extern CFStringRef DCSDictionaryGetName(DCSDictionaryRef dictionary);
 extern CFArrayRef DCSCopyRecordsForSearchString(DCSDictionaryRef dictionary, CFStringRef string, void *, void *);
 
 extern CFDictionaryRef DCSCopyDefinitionMarkup(DCSDictionaryRef dictionary, CFStringRef record);
-extern CFStringRef DCSRecordCopyData(CFTypeRef record);
+extern CFStringRef DCSRecordCopyData(CFTypeRef record, int version);
 extern CFStringRef DCSRecordCopyDataURL(CFTypeRef record);
 extern CFStringRef DCSRecordGetAnchor(CFTypeRef record);
 extern CFStringRef DCSRecordGetAssociatedObj(CFTypeRef record);
@@ -84,8 +84,9 @@ extern CFStringRef DCSRecordGetTitle(CFTypeRef record);
     if (self.headword) {
         self.text = (__bridge_transfer NSString*)DCSCopyTextDefinition(dictionary, (__bridge CFStringRef)self.headword, CFRangeMake(0, CFStringGetLength((__bridge CFStringRef)self.headword)));
     }
-
-    self.HTML = (__bridge_transfer NSString *)DCSRecordCopyData(record);
+    
+    int version = 0x2; // HTML + CSS
+    self.HTML = (__bridge_transfer NSString *)DCSRecordCopyData(record, version);
 
     return self;
 }


### PR DESCRIPTION
fixed DCSRecordCopyData signature and modified the call to get the HTML + CSS version of the definition (instead of just XML)
