### PR TITLE
Get text out of record

### DIFF
--- a/DictionaryKit/TTTDictionary.m
+++ b/DictionaryKit/TTTDictionary.m
@@ -89,7 +89,7 @@ extern CFStringRef DCSRecordGetTitle(CFTypeRef record);
 
     self.headword = (__bridge NSString *)DCSRecordGetHeadword(record);
     if (self.headword) {
-        self.text = (__bridge_transfer NSString*)DCSCopyTextDefinition(dictionary, (__bridge CFStringRef)self.headword, CFRangeMake(0, CFStringGetLength((__bridge CFStringRef)self.headword)));
+        self.text = (__bridge_transfer NSString*)DCSRecordCopyData(record, TTTDictionaryVersionText);
     }
     
     self.HTML = (__bridge_transfer NSString *)DCSRecordCopyData(record, (long)TTTDictionaryVersionHTMLWithPopoverCSS);


### PR DESCRIPTION
## Before this PR

Was populating a record's text via an additional `DCSCopyTextDefinition` API call, passing only the headword.

I've noticed that this might yield an empty result for certain entries , and exhibit unspecified behaviour if there are multiple entries for the same headword.

## After this PR

Extract the text out of the record via `DCSRecordCopyData`, the same way HTML is extracted.
This ensures that multiple entries for the same headword work as expected.